### PR TITLE
Fix `--config` argument in plist to be `--config-file`

### DIFF
--- a/Formula/litra-autotoggle.rb
+++ b/Formula/litra-autotoggle.rb
@@ -50,7 +50,7 @@ class LitraAutotoggle < Formula
   end
 
   service do
-    run [opt_bin / 'litra-autotoggle', '--config', etc / 'litra-autotoggle.yml']
+    run [opt_bin / 'litra-autotoggle', '--config-file', etc / 'litra-autotoggle.yml']
     keep_alive crashed: true
   end
 


### PR DESCRIPTION
Service currently doesn't start as the argument is incorrect.